### PR TITLE
Explain meaning of '.' for data name deprecation

### DIFF
--- a/ddl.dic
+++ b/ddl.dic
@@ -406,7 +406,9 @@ save_definition_replaced.by
     _description.text
 ;
      Name of the data item that should be used instead of the defined data
-     item. The defined data item is deprecated and should not be used.
+     item. The defined data item is deprecated and should not be used. A
+     value of '.' signifies that the data item is deprecated, with no
+     replacement.
 ;
     _name.category_id            definition_replaced
     _name.object_id              by


### PR DESCRIPTION
When a data name is deprecated, with no alternative, a value of '.' is used. Please see message https://www.iucr.org/__data/iucr/lists/ddlm-group/msg01561.html